### PR TITLE
Support all image sizes

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -38,7 +38,7 @@ class Generator:
       u64 = ops.uk(res_output, 2*self.ngf, is_training=self.is_training, norm=self.norm,
           reuse=self.reuse, name='u64')                                 # (?, w/2, h/2, 64)
       u32 = ops.uk(u64, self.ngf, is_training=self.is_training, norm=self.norm,
-          reuse=self.reuse, name='u32')                                 # (?, w, h, 32)
+          reuse=self.reuse, name='u32', output_size=self.image_size)         # (?, w, h, 32)
 
       # conv layer
       # Note: the paper said that ReLU and _norm were used

--- a/model.py
+++ b/model.py
@@ -51,7 +51,7 @@ class CycleGAN:
     self.G = Generator('G', self.is_training, ngf=ngf, norm=norm, image_size=image_size)
     self.D_Y = Discriminator('D_Y',
         self.is_training, norm=norm, use_sigmoid=use_sigmoid)
-    self.F = Generator('F', self.is_training, norm=norm)
+    self.F = Generator('F', self.is_training, norm=norm, image_size=image_size)
     self.D_X = Discriminator('D_X',
         self.is_training, norm=norm, use_sigmoid=use_sigmoid)
 

--- a/ops.py
+++ b/ops.py
@@ -105,6 +105,7 @@ def uk(input, k, reuse=False, norm='instance', is_training=True, name=None, outp
     is_training: boolean or BoolTensor
     reuse: boolean
     name: string, e.g. 'c7sk-32'
+    output_size: integer, desired output size of layer
   Returns:
     4D tensor
   """

--- a/ops.py
+++ b/ops.py
@@ -95,7 +95,7 @@ def n_res_blocks(input, reuse, n=6):
     input = output
   return output
 
-def uk(input, k, reuse=False, norm='instance', is_training=True, name=None):
+def uk(input, k, reuse=False, norm='instance', is_training=True, name=None, output_size=None):
   """ A 3x3 fractional-strided-Convolution-BatchNorm-ReLU layer
       with k filters, stride 1/2
   Args:
@@ -114,7 +114,8 @@ def uk(input, k, reuse=False, norm='instance', is_training=True, name=None):
     weights = _weights("weights",
       shape=[3, 3, k, input_shape[3]])
 
-    output_size = input_shape[1]*2
+    if not output_size:
+      output_size = input_shape[1]*2
     output_shape = [input_shape[0], output_size, output_size, k]
     fsconv = tf.nn.conv2d_transpose(input, weights,
         output_shape=output_shape,


### PR DESCRIPTION
The current code only supports images that are divisible by 4 (e.g 296 works, but 297, 298, and 299 don't). This happens because the weight and height are divided and then multiplied through the layers in generator.py, but the division is integer division so the dimensions don't match at the end. This change lets you specify the output size of the ops.uk function so that it matches the image size correctly.