### PR TITLE
Python 2 support

### DIFF
--- a/build_data.py
+++ b/build_data.py
@@ -1,6 +1,13 @@
 import tensorflow as tf
-import os
 import random
+import os
+
+try:
+  from os import scandir
+except ImportError:
+  # Python 2 polyfill module
+  from scandir import scandir
+    
 
 FLAGS = tf.flags.FLAGS
 
@@ -23,7 +30,7 @@ def data_reader(input_dir, shuffle=True):
   """
   file_paths = []
 
-  for img_file in os.scandir(input_dir):
+  for img_file in scandir(input_dir):
     if img_file.name.endswith('.jpg') and img_file.is_file():
       file_paths.append(img_file.path)
 
@@ -75,7 +82,10 @@ def data_writer(input_dir, output_file):
 
   # create tfrecords dir if not exists
   output_dir = os.path.dirname(output_file)
-  os.makedirs(output_dir, exist_ok=True)
+  try:
+    os.makedirs(output_dir)
+  except os.error, e:
+    pass
 
   images_num = len(file_paths)
 

--- a/train.py
+++ b/train.py
@@ -36,7 +36,10 @@ tf.flags.DEFINE_string('Y', 'data/tfrecords/orange.tfrecords',
 def train():
   current_time = datetime.now().strftime("%Y%m%d-%H%M")
   checkpoints_dir = "checkpoints/{}".format(current_time)
-  os.makedirs(checkpoints_dir, exist_ok=True)
+  try:
+    os.makedirs(checkpoints_dir)
+  except os.error, e:
+    pass
 
   graph = tf.Graph()
   with graph.as_default():


### PR DESCRIPTION
A couple of changes to support python < 3.6

(use the scandir module from pypi if os.scandir isn't available, and don't rely on the exist_ok kwarg to os.makedirs)

Tested with Python 2.7