### PR TITLE
Fix syntax error on Python 3.5

### DIFF
--- a/build_data.py
+++ b/build_data.py
@@ -84,7 +84,7 @@ def data_writer(input_dir, output_file):
   output_dir = os.path.dirname(output_file)
   try:
     os.makedirs(output_dir)
-  except os.error, e:
+  except os.error as e:
     pass
 
   images_num = len(file_paths)


### PR DESCRIPTION
Only changed `except os.error, e` to `except os.error as e` since it could cause syntax error on Python 3.5. Everything else works just fine.