### PR TITLE
Strip "checkpoints/" from the load_model flag

### DIFF
--- a/train.py
+++ b/train.py
@@ -37,7 +37,7 @@ tf.flags.DEFINE_string('load_model', None,
 
 def train():
   if FLAGS.load_model is not None:
-    checkpoints_dir = "checkpoints/" + FLAGS.load_model
+    checkpoints_dir = "checkpoints/" + FLAGS.load_model.lstrip("checkpoints/")
   else:
     current_time = datetime.now().strftime("%Y%m%d-%H%M")
     checkpoints_dir = "checkpoints/{}".format(current_time)


### PR DESCRIPTION
It's an easy mistake to try to pass the path to the model dir (ie. "checkpoints/20170929-1538") rather than the name of the directory ("20170929-1538"). 
If we strip out "checkpoints/", then naive attempts to pass the relative path will work, instead of producing an obscure error message.