### PR TITLE
Fix the default values of lambda1 and lambda2

### DIFF
--- a/model.py
+++ b/model.py
@@ -15,8 +15,8 @@ class CycleGAN:
                image_size=256,
                use_lsgan=True,
                norm='instance',
-               lambda1=10.0,
-               lambda2=10.0,
+               lambda1=10,
+               lambda2=10,
                learning_rate=2e-4,
                beta1=0.5,
                ngf=64

--- a/train.py
+++ b/train.py
@@ -14,10 +14,10 @@ tf.flags.DEFINE_bool('use_lsgan', True,
                      'use lsgan (mean squared error) or cross entropy loss, default: True')
 tf.flags.DEFINE_string('norm', 'instance',
                        '[instance, batch] use instance norm or batch norm, default: instance')
-tf.flags.DEFINE_integer('lambda1', 10.0,
-                        'weight for forward cycle loss (X->Y->X), default: 10.0')
-tf.flags.DEFINE_integer('lambda2', 10.0,
-                        'weight for backward cycle loss (Y->X->Y), default: 10.0')
+tf.flags.DEFINE_integer('lambda1', 10,
+                        'weight for forward cycle loss (X->Y->X), default: 10')
+tf.flags.DEFINE_integer('lambda2', 10,
+                        'weight for backward cycle loss (Y->X->Y), default: 10')
 tf.flags.DEFINE_float('learning_rate', 2e-4,
                       'initial learning rate for Adam, default: 0.0002')
 tf.flags.DEFINE_float('beta1', 0.5,


### PR DESCRIPTION
With TensorFlow 1.5.0, I get the following error when running `train.py`:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_flag.py", line 166, in _parse
    return self.parser.parse(argument)
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_argument_parser.py", line 152, in parse
    val = self.convert(argument)
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_argument_parser.py", line 268, in convert
    type(argument)))
TypeError: Expect argument to be a string or int, found <class 'float'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "source/train.py", line 18, in <module>
    'weight for forward cycle loss (X->Y->X), default: 10.0')
  File "/usr/local/lib/python3.5/dist-packages/tensorflow/python/platform/flags.py", line 58, in wrapper
    return original_function(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_defines.py", line 315, in DEFINE_integer
    DEFINE(parser, name, default, help, flag_values, serializer, **args)
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_defines.py", line 81, in DEFINE
    DEFINE_flag(_flag.Flag(parser, serializer, name, default, help, **args),
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_flag.py", line 107, in __init__
    self._set_default(default)
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_flag.py", line 196, in _set_default
    self.default = self._parse(value)
  File "/usr/local/lib/python3.5/dist-packages/absl/flags/_flag.py", line 169, in _parse
    'flag --%s=%s: %s' % (self.name, argument, e))
absl.flags._exceptions.IllegalFlagValueError: flag --lambda1=10.0: Expect argument to be a string or int, found <class 'float'>
```

Apparently, `absl` has now stricter rules regarding how flags are being declared.